### PR TITLE
Update actions/cache to v3

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache-Go
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod              # Module download cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Cache-Go
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod              # Module download cache


### PR DESCRIPTION
## Summary
- fix workflow failures by updating deprecated `actions/cache` references from `v1` to `v3`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6865308bc934832fb7957121c21ecb67