### PR TITLE
Introduce generic map helpers

### DIFF
--- a/dsquery.go
+++ b/dsquery.go
@@ -110,31 +110,35 @@ func (qa *And) Query(dsClient DatastoreClient, ctx context.Context) ([]*datastor
 }
 
 // MapIntersect intersects `m` with `items` and returns a new map containing only
-// the items whose derived key exists in `m`.
-func MapIntersect[K comparable, V any](m map[K]V, items []V, keyFn func(V) K) map[K]V {
+// entries from `m` whose derived item key exists in `m`. Invalid derived keys are
+// ignored.
+func MapIntersect[K comparable, V any, T any](m map[K]V, items []T, keyFn func(T) (K, bool)) map[K]V {
 	s := len(m)
 	if s > len(items) {
 		s = len(items)
 	}
 	m2 := make(map[K]V, s)
-	for _, v := range items {
-		k := keyFn(v)
-		if _, ok := m[k]; ok {
-			m2[k] = v
+	for _, item := range items {
+		if k, ok := keyFn(item); ok {
+			if v, exists := m[k]; exists {
+				m2[k] = v
+			}
 		}
 	}
 	return m2
 }
 
-// MapExclude removes all entries from `m` whose keys appear in `items`.
-func MapExclude[K comparable, V any](m map[K]V, items []V, keyFn func(V) K) map[K]V {
+// MapExclude removes all entries from `m` whose keys appear in `items`. Invalid
+// derived keys are ignored.
+func MapExclude[K comparable, V any, T any](m map[K]V, items []T, keyFn func(T) (K, bool)) map[K]V {
 	m2 := make(map[K]V, len(m))
 	for k, v := range m {
 		m2[k] = v
 	}
-	for _, v := range items {
-		k := keyFn(v)
-		delete(m2, k)
+	for _, item := range items {
+		if k, ok := keyFn(item); ok {
+			delete(m2, k)
+		}
 	}
 	return m2
 }
@@ -142,25 +146,23 @@ func MapExclude[K comparable, V any](m map[K]V, items []V, keyFn func(V) K) map[
 // DSKeyMapMergeAnd intersects a set with a slice of datastore keys using
 // MapIntersect. Nil keys in `keys` are ignored.
 func DSKeyMapMergeAnd(m map[string]*datastore.Key, keys []*datastore.Key) map[string]*datastore.Key {
-	filtered := make([]*datastore.Key, 0, len(keys))
-	for _, k := range keys {
-		if k != nil {
-			filtered = append(filtered, k)
+	return MapIntersect(m, keys, func(k *datastore.Key) (string, bool) {
+		if k == nil {
+			return "", false
 		}
-	}
-	return MapIntersect(m, filtered, func(k *datastore.Key) string { return k.Encode() })
+		return k.Encode(), true
+	})
 }
 
 // DSKeyMapMergeNot removes keys from a set using MapExclude. Nil keys in `keys`
 // are ignored.
 func DSKeyMapMergeNot(m map[string]*datastore.Key, keys []*datastore.Key) map[string]*datastore.Key {
-	filtered := make([]*datastore.Key, 0, len(keys))
-	for _, k := range keys {
-		if k != nil {
-			filtered = append(filtered, k)
+	return MapExclude(m, keys, func(k *datastore.Key) (string, bool) {
+		if k == nil {
+			return "", false
 		}
-	}
-	return MapExclude(m, filtered, func(k *datastore.Key) string { return k.Encode() })
+		return k.Encode(), true
+	})
 }
 
 // The NOT query

--- a/dsquery_test.go
+++ b/dsquery_test.go
@@ -517,3 +517,32 @@ func TestDSKeyMapMergeAnd(t *testing.T) {
 		}
 	})
 }
+
+func TestDSKeyMapMergeNot(t *testing.T) {
+	m := KeyMapCreate("1", "2")
+	keys := []*datastore.Key{datastore.NameKey("asdf", "1", nil)}
+	got := DSKeyMapMergeNot(m, keys)
+	if !KeyArraysEqual(ExtractMapStringKeysKey(got), KeyArrayCreate("2")) {
+		t.Errorf("DSKeyMapMergeNot() = %v, want %v", got, KeyArrayCreate("2"))
+	}
+}
+
+func TestMapIntersect(t *testing.T) {
+	m := map[string]string{"1": "a", "2": "b"}
+	items := []string{"2", "3"}
+	got := MapIntersect(m, items, func(v string) string { return v })
+	want := map[string]string{"2": "2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("MapIntersect() = %v, want %v", got, want)
+	}
+}
+
+func TestMapExclude(t *testing.T) {
+	m := map[string]string{"1": "a", "2": "b"}
+	items := []string{"1"}
+	got := MapExclude(m, items, func(v string) string { return v })
+	want := map[string]string{"2": "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("MapExclude() = %v, want %v", got, want)
+	}
+}

--- a/dsquery_test.go
+++ b/dsquery_test.go
@@ -530,8 +530,8 @@ func TestDSKeyMapMergeNot(t *testing.T) {
 func TestMapIntersect(t *testing.T) {
 	m := map[string]string{"1": "a", "2": "b"}
 	items := []string{"2", "3"}
-	got := MapIntersect(m, items, func(v string) string { return v })
-	want := map[string]string{"2": "2"}
+	got := MapIntersect(m, items, func(v string) (string, bool) { return v, true })
+	want := map[string]string{"2": "b"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("MapIntersect() = %v, want %v", got, want)
 	}
@@ -540,7 +540,7 @@ func TestMapIntersect(t *testing.T) {
 func TestMapExclude(t *testing.T) {
 	m := map[string]string{"1": "a", "2": "b"}
 	items := []string{"1"}
-	got := MapExclude(m, items, func(v string) string { return v })
+	got := MapExclude(m, items, func(v string) (string, bool) { return v, true })
 	want := map[string]string{"2": "b"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("MapExclude() = %v, want %v", got, want)


### PR DESCRIPTION
## Summary
- add generic `MapIntersect` and `MapExclude`
- implement datastore helpers using the new generics
- add coverage for generic helpers and datastore wrappers

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6865de9e1978832fa9aa13704a09e4a5