### PR TITLE
ci: fix GitHub release creation fallback when discussions are disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,9 @@ jobs:
           if [[ -n "$prerelease" ]]; then
             gh release create "$TAG" --generate-notes $prerelease || true
           else
-            gh release create "$TAG" --generate-notes $discussion_arg || \
-              gh release create "$TAG" --generate-notes
+            gh release create "$TAG" --generate-notes $discussion_arg || {
+              if ! gh release view "$TAG" >/dev/null 2>&1; then
+                gh release create "$TAG" --generate-notes
+              fi
+            }
           fi


### PR DESCRIPTION
ci: fix GitHub release creation fallback when discussions are disabled

When a repository has discussions disabled, the first `gh release create` command correctly creates the release but exits with an error status (HTTP 404/422) when attempting to create a discussion. The fallback `gh release create` command then fails because the release already exists. This change checks if the release was successfully created before attempting to recreate it in the fallback.

---
*PR created automatically by Jules for task [11023433133575894829](https://jules.google.com/task/11023433133575894829) started by @arran4*