### PR TITLE
Refine generic map helpers

### DIFF
--- a/dsquery.go
+++ b/dsquery.go
@@ -112,6 +112,9 @@ func (qa *And) Query(ctx context.Context, dsClient DatastoreClient) ([]*datastor
 // MapIntersect intersects `m` with `items` and returns a new map containing only
 // the items whose derived key exists in `m`.
 func MapIntersect[K comparable, V any, I any](m map[K]V, items []I, keyFn func(I) (K, bool)) map[K]V {
+	if len(m) == 0 {
+		return m
+	}
 	s := len(m)
 	if s > len(items) {
 		s = len(items)
@@ -131,6 +134,9 @@ func MapIntersect[K comparable, V any, I any](m map[K]V, items []I, keyFn func(I
 
 // MapExclude removes all entries from `m` whose keys appear in `items`.
 func MapExclude[K comparable, V any, I any](m map[K]V, items []I, keyFn func(I) (K, bool)) map[K]V {
+	if len(m) == 0 {
+		return m
+	}
 	m2 := make(map[K]V, len(m))
 	for k, v := range m {
 		m2[k] = v

--- a/dsquery.go
+++ b/dsquery.go
@@ -109,38 +109,62 @@ func (qa *And) Query(ctx context.Context, dsClient DatastoreClient) ([]*datastor
 	return ExtractMapStringKeysKey(m), nil
 }
 
-// Helper function to merge a set with an array, and produce a set of datastore keys.
-func DSKeyMapMergeAnd(m map[string]*datastore.Key, keys []*datastore.Key) map[string]*datastore.Key {
+// MapIntersect intersects `m` with `items` and returns a new map containing only
+// the items whose derived key exists in `m`.
+func MapIntersect[K comparable, V any, I any](m map[K]V, items []I, keyFn func(I) (K, bool)) map[K]V {
 	s := len(m)
-	if s > len(keys) {
-		s = len(keys)
+	if s > len(items) {
+		s = len(items)
 	}
-	m2 := make(map[string]*datastore.Key, s)
-	for _, k := range keys {
-		if k == nil {
+	m2 := make(map[K]V, s)
+	for _, v := range items {
+		k, ok := keyFn(v)
+		if !ok {
 			continue
 		}
-		ks := k.Encode()
-		if _, ok := m[ks]; ok {
-			m2[ks] = k
+		if val, ok2 := m[k]; ok2 {
+			m2[k] = val
 		}
 	}
 	return m2
 }
 
-// Helper function to remove keys from a set and produce a new set of datastore keys.
-func DSKeyMapMergeNot(m map[string]*datastore.Key, keys []*datastore.Key) map[string]*datastore.Key {
-	m2 := make(map[string]*datastore.Key, len(m))
+// MapExclude removes all entries from `m` whose keys appear in `items`.
+func MapExclude[K comparable, V any, I any](m map[K]V, items []I, keyFn func(I) (K, bool)) map[K]V {
+	m2 := make(map[K]V, len(m))
 	for k, v := range m {
 		m2[k] = v
 	}
-	for _, k := range keys {
-		if k == nil {
+	for _, v := range items {
+		k, ok := keyFn(v)
+		if !ok {
 			continue
 		}
-		delete(m2, k.Encode())
+		delete(m2, k)
 	}
 	return m2
+}
+
+// DSKeyMapMergeAnd intersects a set with a slice of datastore keys using
+// MapIntersect. Nil keys in `keys` are ignored.
+func DSKeyMapMergeAnd(m map[string]*datastore.Key, keys []*datastore.Key) map[string]*datastore.Key {
+	return MapIntersect(m, keys, func(k *datastore.Key) (string, bool) {
+		if k == nil {
+			return "", false
+		}
+		return k.Encode(), true
+	})
+}
+
+// DSKeyMapMergeNot removes keys from a set using MapExclude. Nil keys in `keys`
+// are ignored.
+func DSKeyMapMergeNot(m map[string]*datastore.Key, keys []*datastore.Key) map[string]*datastore.Key {
+	return MapExclude(m, keys, func(k *datastore.Key) (string, bool) {
+		if k == nil {
+			return "", false
+		}
+		return k.Encode(), true
+	})
 }
 
 // The NOT query

--- a/dsquery_test.go
+++ b/dsquery_test.go
@@ -518,8 +518,13 @@ func TestDSKeyMapMergeNot(t *testing.T) {
 
 func TestMapIntersect(t *testing.T) {
 	m := map[string]string{"1": "a", "2": "b"}
-	items := []string{"2", "3"}
-	got := MapIntersect(m, items, func(v string) (string, bool) { return v, true })
+	items := []string{"2", "3", "ignored"}
+	got := MapIntersect(m, items, func(v string) (string, bool) {
+		if v == "ignored" {
+			return "", false
+		}
+		return v, true
+	})
 	want := map[string]string{"2": "b"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("MapIntersect() = %v, want %v", got, want)
@@ -528,8 +533,13 @@ func TestMapIntersect(t *testing.T) {
 
 func TestMapExclude(t *testing.T) {
 	m := map[string]string{"1": "a", "2": "b"}
-	items := []string{"1"}
-	got := MapExclude(m, items, func(v string) (string, bool) { return v, true })
+	items := []string{"1", "ignored"}
+	got := MapExclude(m, items, func(v string) (string, bool) {
+		if v == "ignored" {
+			return "", false
+		}
+		return v, true
+	})
 	want := map[string]string{"2": "b"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("MapExclude() = %v, want %v", got, want)

--- a/dsquery_test.go
+++ b/dsquery_test.go
@@ -506,3 +506,32 @@ func TestDSKeyMapMergeAnd(t *testing.T) {
 		}
 	})
 }
+
+func TestDSKeyMapMergeNot(t *testing.T) {
+	m := KeyMapCreate("1", "2")
+	keys := []*datastore.Key{datastore.NameKey("asdf", "1", nil)}
+	got := DSKeyMapMergeNot(m, keys)
+	if !KeyArraysEqual(ExtractMapStringKeysKey(got), KeyArrayCreate("2")) {
+		t.Errorf("DSKeyMapMergeNot() = %v, want %v", got, KeyArrayCreate("2"))
+	}
+}
+
+func TestMapIntersect(t *testing.T) {
+	m := map[string]string{"1": "a", "2": "b"}
+	items := []string{"2", "3"}
+	got := MapIntersect(m, items, func(v string) (string, bool) { return v, true })
+	want := map[string]string{"2": "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("MapIntersect() = %v, want %v", got, want)
+	}
+}
+
+func TestMapExclude(t *testing.T) {
+	m := map[string]string{"1": "a", "2": "b"}
+	items := []string{"1"}
+	got := MapExclude(m, items, func(v string) (string, bool) { return v, true })
+	want := map[string]string{"2": "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("MapExclude() = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
- Updated `MapIntersect` to take an independent item type `I`, use a `func(I) (K, bool)` as `keyFn`, and preserve values from the source map.
- Updated `MapExclude` to take an independent item type `I`, use a `func(I) (K, bool)` as `keyFn`, and ignore invalid keys via the boolean result.
- Updated `DSKeyMapMergeAnd` to use `MapIntersect` directly without creating an intermediate slice for non-nil items.
- Updated `DSKeyMapMergeNot` to use `MapExclude` directly without creating an intermediate slice for non-nil items.
- Updated tests for generic helpers to use the new `(K, bool)` signature and correctly assert value preservation.

---
*PR created automatically by Jules for task [5135350285634048611](https://jules.google.com/task/5135350285634048611) started by @arran4*